### PR TITLE
Fix temp_buffer to allocate two indices instead of one.

### DIFF
--- a/src/dmg/dmg07.cpp
+++ b/src/dmg/dmg07.cpp
@@ -278,7 +278,7 @@ bool DMG_SIO::four_player_receive_byte()
 {
 	#ifdef GBE_NETPLAY
 
-	u8 temp_buffer[1];
+	u8 temp_buffer[2];
 	temp_buffer[0] = temp_buffer[1] = 0;
 
 	//Check the status of connection


### PR DESCRIPTION
Not familiar with this codebase at all, but this looks like a pretty clear typo to me. temp_buffer is used in other functions in this file with two bytes instead of just one. This also fixes a few warnings (on Clang at least) that indicate that we're accessing an out-of-bounds array index (see use of temp_buffer[1] on the very next line.)