### PR TITLE
Add Net Gate functionality

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -143,6 +143,7 @@ namespace config
 	//Netplay settings
 	bool use_netplay = true;
 	bool netplay_hard_sync = true;
+	bool use_net_gate = false;
 	u32 netplay_sync_threshold = 32;
 	u16 netplay_server_port = 2000;
 	u16 netplay_client_port = 2001;
@@ -2137,6 +2138,24 @@ bool parse_ini_file()
 			}
 		}
 
+		//Use Net Gate
+		else if(ini_item == "#use_net_gate")
+		{
+			if((x + 1) < size) 
+			{
+				util::from_str(ini_opts[++x], output);
+
+				if(output == 1) { config::use_net_gate = true; }
+				else { config::use_net_gate = false; }
+			}
+
+			else 
+			{
+				std::cout<<"GBE::Error - Could not parse gbe.ini (#use_net_gate) \n";
+				return false;
+			}
+		}
+
 		//Netplay sync threshold
 		if(ini_item == "#netplay_sync_threshold")
 		{
@@ -2880,6 +2899,15 @@ bool save_ini_file()
 			std::string val = (config::use_netplay) ? "1" : "0";
 
 			output_lines[line_pos] = "[#use_netplay:" + val + "]";
+		}
+
+		//Use Net Gate
+		else if(ini_item == "#use_net_gate")
+		{
+			line_pos = output_count[x];
+			std::string val = (config::use_net_gate) ? "1" : "0";
+
+			output_lines[line_pos] = "[#use_net_gate:" + val + "]";
 		}
 
 		//Use netplay hard sync

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -134,6 +134,7 @@ namespace config
 
 	extern bool use_netplay;
 	extern bool netplay_hard_sync;
+	extern bool use_net_gate;
 	extern u32 netplay_sync_threshold;
 	extern u16 netplay_server_port;
 	extern u16 netplay_client_port;

--- a/src/gba/sio.cpp
+++ b/src/gba/sio.cpp
@@ -524,7 +524,7 @@ void AGB_SIO::process_network_communication()
 	#ifdef GBE_NETPLAY
 
 	//If no communication with another GBE+ instance has been established yet, see if a connection can be made
-	if((!sio_stat.connected) && (sio_stat.sio_type != INVALID_GBA_DEVICE) && (sio_stat.sio_type != GBA_BATTLE_CHIP_GATE))
+	if((!sio_stat.connected) && (sio_stat.sio_type != INVALID_GBA_DEVICE) && (!config::use_net_gate))
 	{
 		//Try to accept incoming connections to the server
 		if(!server.connected)
@@ -1029,7 +1029,7 @@ void AGB_SIO::net_gate_process()
 			//Check remote socket for any connections
 			if(server.remote_socket = SDLNet_TCP_Accept(server.host_socket))
 			{
-				u8 temp_buffer[3] = {0, 0, 0} ;
+				u8 temp_buffer[3] = {0, 0, 0};
 
 				//Net Gate protocol is 1-shot, no response, 3 bytes
 				if(SDLNet_TCP_Recv(server.remote_socket, temp_buffer, 3) > 0)

--- a/src/gba/sio.h
+++ b/src/gba/sio.h
@@ -98,6 +98,7 @@ class AGB_SIO
 		u8 data_inc;
 		u8 data_dec;
 		u32 data_count;
+		u32 net_gate_count;
 		bool start;
 		battle_chip_gate_state current_state;
 	} chip_gate;

--- a/src/gba/sio.h
+++ b/src/gba/sio.h
@@ -121,6 +121,7 @@ class AGB_SIO
 	void soul_doll_adapter_process();
 
 	void battle_chip_gate_process();
+	void net_gate_process();
 };
 
 #endif // GBA_SIO

--- a/src/gba/swi.cpp
+++ b/src/gba/swi.cpp
@@ -121,13 +121,13 @@ void ARM7::process_swi(u32 comment)
 
 		//CPUSet
 		case 0xB:
-			//std::cout<<"SWI::CPU Set \n";
+			std::cout<<"SWI::CPU Set \n";
 			swi_cpuset();
 			break;
 
 		//CPUFastSet
 		case 0xC:
-			//std::cout<<"SWI::CPU Fast Set \n";
+			std::cout<<"SWI::CPU Fast Set \n";
 			swi_cpufastset();
 			break;
 
@@ -139,13 +139,13 @@ void ARM7::process_swi(u32 comment)
 
 		//BGAffineSet
 		case 0xE:
-			//std::cout<<"SWI::BG Affine Set \n";
+			std::cout<<"SWI::BG Affine Set \n";
 			swi_bgaffineset();
 			break;
 
 		//OBJAffineSet
 		case 0xF:
-			//std::cout<<"SWI::OBJ Affine Set \n";
+			std::cout<<"SWI::OBJ Affine Set \n";
 			swi_objaffineset();
 			break;
 
@@ -157,13 +157,13 @@ void ARM7::process_swi(u32 comment)
 
 		//LZ77UnCompWram
 		case 0x11:
-			//std::cout<<"SWI::LZ77 Uncompress Work RAM \n";
+			std::cout<<"SWI::LZ77 Uncompress Work RAM \n";
 			swi_lz77uncompvram();
 			break;
 
 		//LZ77UnCompVram
 		case 0x12:
-			//std::cout<<"SWI::LZ77 Uncompress Video RAM \n";
+			std::cout<<"SWI::LZ77 Uncompress Video RAM \n";
 			swi_lz77uncompvram();
 			break;
 

--- a/src/gba/swi.cpp
+++ b/src/gba/swi.cpp
@@ -121,13 +121,13 @@ void ARM7::process_swi(u32 comment)
 
 		//CPUSet
 		case 0xB:
-			std::cout<<"SWI::CPU Set \n";
+			//std::cout<<"SWI::CPU Set \n";
 			swi_cpuset();
 			break;
 
 		//CPUFastSet
 		case 0xC:
-			std::cout<<"SWI::CPU Fast Set \n";
+			//std::cout<<"SWI::CPU Fast Set \n";
 			swi_cpufastset();
 			break;
 
@@ -139,13 +139,13 @@ void ARM7::process_swi(u32 comment)
 
 		//BGAffineSet
 		case 0xE:
-			std::cout<<"SWI::BG Affine Set \n";
+			//std::cout<<"SWI::BG Affine Set \n";
 			swi_bgaffineset();
 			break;
 
 		//OBJAffineSet
 		case 0xF:
-			std::cout<<"SWI::OBJ Affine Set \n";
+			//std::cout<<"SWI::OBJ Affine Set \n";
 			swi_objaffineset();
 			break;
 
@@ -157,13 +157,13 @@ void ARM7::process_swi(u32 comment)
 
 		//LZ77UnCompWram
 		case 0x11:
-			std::cout<<"SWI::LZ77 Uncompress Work RAM \n";
+			//std::cout<<"SWI::LZ77 Uncompress Work RAM \n";
 			swi_lz77uncompvram();
 			break;
 
 		//LZ77UnCompVram
 		case 0x12:
-			std::cout<<"SWI::LZ77 Uncompress Video RAM \n";
+			//std::cout<<"SWI::LZ77 Uncompress Video RAM \n";
 			swi_lz77uncompvram();
 			break;
 

--- a/src/gbe.ini
+++ b/src/gbe.ini
@@ -267,6 +267,12 @@
 //1 - use "hard" sync, 0 - use "soft" sync
 [#use_netplay_hard_sync:1]
 
+//Enable Net Gate functionality
+//The "Net Gate" is simply GBE's ablity to receive Battle Chips via HTTP requests
+//This is ONLY for use with Battle Chip Gate emulation on the GBA
+//This requires both netplay to be enabled and one of the Battle Chip Gates set as the emulated serial IO device
+[#use_net_gate:1]
+
 //Netplay sync threshold
 //The number of emulated system cycles GBE+ will run before waiting to sync over netplay
 //This option only applies when "hard" syncing is enabled. The lower the number the more frequent the emulators sync

--- a/src/gbe.ini
+++ b/src/gbe.ini
@@ -268,10 +268,10 @@
 [#use_netplay_hard_sync:1]
 
 //Enable Net Gate functionality
-//The "Net Gate" is simply GBE's ablity to receive Battle Chips via HTTP requests
+//The "Net Gate" is simply GBE's ablity to receive Battle Chips via TCP connection
 //This is ONLY for use with Battle Chip Gate emulation on the GBA
 //This requires both netplay to be enabled and one of the Battle Chip Gates set as the emulated serial IO device
-[#use_net_gate:1]
+[#use_net_gate:0]
 
 //Netplay sync threshold
 //The number of emulated system cycles GBE+ will run before waiting to sync over netplay


### PR DESCRIPTION
The "Net Gate" is simply an interface to send Battle Chip data to GBE+ via TCP. It can be used in conjunction with another application (such as a PHP script as a backend and HTML/CSS/JavaScript as the frontend) to send Chip IDs. Protocol is fairly simple, just 3 bytes are used:

1) 0x80
2) CHIP_ID_HI
3) CHIP_ID_LO

GBE+ does not respond to the sent message, so it's fire and forget. Anything that can manipulate raw sockets can send communicate with GBE+. As such, the interface could be anything, from a webpage, to a smartphone app, or even some sort of CLI script.

![net_gate](https://user-images.githubusercontent.com/7418176/53295109-6dac5a00-37b9-11e9-8851-775d6c4c7b54.png)
