### PR TITLE
Fix compilation error in play_yan.cpp

### DIFF
--- a/src/gba/play_yan.cpp
+++ b/src/gba/play_yan.cpp
@@ -598,7 +598,7 @@ u8 AGB_MMU::read_play_yan(u32 address)
 /****** Reads from Play-Yan I/O ******/
 u8 AGB_MMU::read_nmp(u32 address)
 {
-	result = 0;
+	u8 result = 0;
 	return result;
 }
 


### PR DESCRIPTION
Fixes compilation error due to result not being properly declared in AGB_MMU::read_nmp.