### PR TITLE
[Qt] Fix a typo in the settings dialog code

### DIFF
--- a/src/qt/general_settings.cpp
+++ b/src/qt/general_settings.cpp
@@ -2200,7 +2200,7 @@ void gen_settings::set_ogl()
 	else
 	{
 		ogl_frag_shader->setEnabled(false);
-		ogl_frag_shader->setEnabled(false);
+		ogl_vert_shader->setEnabled(false);
 	}
 }
 


### PR DESCRIPTION
This part of the code set the fragment shader widget to false twice, instead of the second time being to the vertex shader widget.