### PR TITLE
[Qt] Consistently use a fully opaque alpha value for colors in OpenGL…

### DIFF
--- a/src/data/shaders/grayscale.fs
+++ b/src/data/shaders/grayscale.fs
@@ -24,7 +24,7 @@ uniform float ext_data_2;
 void main()
 {
 	vec4 input_color = texture(screen_texture, texture_coordinates);
-	vec4 output_color = vec4(0, 0, 0, 0);
+	vec4 output_color = vec4(0.0, 0.0, 0.0, 1.0);
 
 	output_color.r = (input_color.r * 0.21) + (input_color.g * 0.72) + (input_color.b * 0.07);
 	output_color.g = output_color.r;

--- a/src/data/shaders/lcd_mode.fs
+++ b/src/data/shaders/lcd_mode.fs
@@ -122,6 +122,7 @@ void hsl_to_rgb(in vec4 hsl_values, out vec4 output_color)
 	output_color.r = r;
 	output_color.g = g;
 	output_color.b = b;
+	output_color.a = 1.0;
 }
 
 void main()

--- a/src/data/shaders/pastel.fs
+++ b/src/data/shaders/pastel.fs
@@ -132,6 +132,7 @@ void hsl_to_rgb(in vec4 hsl_values, out vec4 output_color)
 	output_color.r = r;
 	output_color.g = g;
 	output_color.b = b;
+	output_color.a = 1.0;
 }
 
 void main()

--- a/src/data/shaders/sepia.fs
+++ b/src/data/shaders/sepia.fs
@@ -24,7 +24,7 @@ uniform float ext_data_2;
 void main()
 {
 	vec4 input_color = texture(screen_texture, texture_coordinates);
-	vec4 output_color = vec4(0, 0, 0, 0);
+	vec4 output_color = vec4(0.0, 0.0, 0.0, 1.0);
 
 	output_color.r = (input_color.r * 0.393) + (input_color.g * 0.769) + (input_color.b * 0.189);
 	output_color.g = (input_color.r * 0.349) + (input_color.g * 0.686) + (input_color.b * 0.168);

--- a/src/data/shaders/spotlight.fs
+++ b/src/data/shaders/spotlight.fs
@@ -133,6 +133,7 @@ void hsl_to_rgb(in vec4 hsl_values, out vec4 output_color)
 	output_color.r = r;
 	output_color.g = g;
 	output_color.b = b;
+	output_color.a = 1.0;
 }
 
 //Find the distance between two points

--- a/src/data/shaders/tv_mode.fs
+++ b/src/data/shaders/tv_mode.fs
@@ -127,6 +127,7 @@ void hsl_to_rgb(in vec4 hsl_values, out vec4 output_color)
 	output_color.r = r;
 	output_color.g = g;
 	output_color.b = b;
+	output_color.a = 1.0;
 }
 
 void main()

--- a/src/data/shaders/washout.fs
+++ b/src/data/shaders/washout.fs
@@ -131,6 +131,7 @@ void hsl_to_rgb(in vec4 hsl_values, out vec4 output_color)
 	output_color.r = r;
 	output_color.g = g;
 	output_color.b = b;
+	output_color.a = 1.0;
 }
 
 void main()

--- a/src/qt/ogl_manager.cpp
+++ b/src/qt/ogl_manager.cpp
@@ -127,7 +127,7 @@ void ogl_manager::paint()
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 
-    	glClearColor(0,0,0,0);
+    	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     	glClear(GL_COLOR_BUFFER_BIT);
 
 	//Use shader


### PR DESCRIPTION
… code
The OpenGL widget has flickering in KDE Wayland because some pixels appear to have a transparent alpha. The background set by glClearColor is affected and some shaders too. This seems to be the only platform affected by this, but being explicit about wanting an opaque color doesn't hurt.