### PR TITLE
[Qt] Default the "maintain-aspect-ratio" config option to true

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -167,7 +167,7 @@ namespace config
 	s8 resize_mode = 0;
 
 	//Aspect ratio
-	bool maintain_aspect_ratio = false;
+	bool maintain_aspect_ratio = true;
 
 	//LCD configuration (NDS primarily)
 	u8 lcd_config = 0;

--- a/src/gbe.ini
+++ b/src/gbe.ini
@@ -154,7 +154,7 @@
 [#scaling_factor:1]
 
 //Maintains aspect ratio when scaling the window (Qt-only) : 1 to enable, 0 to disable
-[#maintain_aspect_ratio:0]
+[#maintain_aspect_ratio:1]
 
 //Max FPS
 // 0 = Default (e.g. ~60FPS) for emulated system, otherwise 1 - 65535


### PR DESCRIPTION
This seems like a pretty sensible default. I'm not sure why would anyone want to have it off.