### PR TITLE
[Qt] Fix null guard to check against the correct buffer in the OpenGL…

### DIFF
--- a/src/qt/screens.cpp
+++ b/src/qt/screens.cpp
@@ -122,7 +122,7 @@ void hard_screen::initializeGL()
 /****** Hardware screen paint event ******/
 void hard_screen::paintGL()
 {
-	if(qt_gui::screen == NULL)
+	if(qt_gui::final_screen == NULL)
 	{
 		QPainter painter(this);
 		painter.setPen(Qt::black);


### PR DESCRIPTION
… widget

When we are painting the hard_screen widget, we need to check against the "final_screen" buffer, not the "screen" buffer that is used by soft_screen.