### PR TITLE
[Qt] Exit full screen when pressing the Esc key

### DIFF
--- a/src/qt/main_menu.cpp
+++ b/src/qt/main_menu.cpp
@@ -1128,6 +1128,7 @@ void main_menu::keyPressEvent(QKeyEvent* event)
 
 				//Fullscreen
 				case SDLK_F12:
+				case SDLK_ESCAPE:
 					findChild<QAction*>("fullscreen_action")->setChecked(false);
 					fullscreen();
 					break;


### PR DESCRIPTION
You can toggle fullscreen with the F12 key, but having Esc bind to only exiting full screen is useful too, and probably what many users expect. Video players like VLC, and browsers like Firefox and Chrome do this too.