### PR TITLE
Don't include headers from SDL2/

### DIFF
--- a/src/common/config.h
+++ b/src/common/config.h
@@ -12,7 +12,7 @@
 #define EMU_CONFIG
 
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <vector>
 #include <string>
 #include <sstream>

--- a/src/common/core_emu.h
+++ b/src/common/core_emu.h
@@ -12,7 +12,7 @@
 #ifndef CORE_EMU
 #define CORE_EMU
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <string>
 #include <vector>
 

--- a/src/common/dmg_core_pad.h
+++ b/src/common/dmg_core_pad.h
@@ -12,7 +12,7 @@
 #ifndef DMG_CORE_PAD
 #define DMG_CORE_PAD
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "common/common.h"
 

--- a/src/common/gx_util.h
+++ b/src/common/gx_util.h
@@ -15,7 +15,7 @@
 #include <vector>
 #include <string>
 
-#include <SDL2/SDL_opengl.h>
+#include <SDL_opengl.h>
 
 #include "common.h"
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "common.h"
 

--- a/src/dmg/apu.h
+++ b/src/dmg/apu.h
@@ -12,8 +12,8 @@
 #ifndef GB_APU
 #define GB_APU
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_audio.h>
+#include <SDL.h>
+#include <SDL_audio.h>
 #include "mmu.h"
 
 class DMG_APU

--- a/src/dmg/core.cpp
+++ b/src/dmg/core.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 
 #ifdef GBE_IMAGE_FORMATS
-#include <SDL2/SDL_image.h>
+#include <SDL_image.h>
 #endif
 
 #include "common/util.h"

--- a/src/dmg/gamepad.cpp
+++ b/src/dmg/gamepad.cpp
@@ -9,7 +9,7 @@
 // Reads and writes to the P1 register
 // Handles input from keyboard using SDL events
 
-#include "SDL2/SDL_sensor.h"
+#include "SDL_sensor.h"
 
 #include "gamepad.h"
 

--- a/src/dmg/gamepad.h
+++ b/src/dmg/gamepad.h
@@ -12,7 +12,7 @@
 #ifndef GB_GAMEPAD
 #define GB_GAMEPAD
 
-#include "SDL2/SDL.h"
+#include "SDL.h"
 #include <string>
 #include <iostream>
 

--- a/src/dmg/lcd.h
+++ b/src/dmg/lcd.h
@@ -12,8 +12,8 @@
 #ifndef GB_LCD
 #define GB_LCD
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_opengl.h"
+#include "SDL.h"
+#include "SDL_opengl.h"
 #include "mmu.h"
 
 class DMG_LCD

--- a/src/dmg/sio.h
+++ b/src/dmg/sio.h
@@ -17,7 +17,7 @@
 #define GB_SIO
 
 #ifdef GBE_NETPLAY
-#include <SDL2/SDL_net.h>
+#include <SDL_net.h>
 #endif
 
 #include "mmu.h"

--- a/src/gba/apu.h
+++ b/src/gba/apu.h
@@ -12,8 +12,8 @@
 #ifndef GBA_APU
 #define GBA_APU
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_audio.h>
+#include <SDL.h>
+#include <SDL_audio.h>
 #include "mmu.h"
 
 class AGB_APU

--- a/src/gba/core.cpp
+++ b/src/gba/core.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 
 #ifdef GBE_IMAGE_FORMATS
-#include <SDL2/SDL_image.h>
+#include <SDL_image.h>
 #endif
 
 #include "common/util.h"

--- a/src/gba/gamepad.h
+++ b/src/gba/gamepad.h
@@ -12,7 +12,7 @@
 #ifndef GBA_GAMEPAD
 #define GBA_GAMEPAD
 
-#include "SDL2/SDL.h"
+#include "SDL.h"
 #include <string>
 #include <iostream>
 

--- a/src/gba/jukebox.cpp
+++ b/src/gba/jukebox.cpp
@@ -9,7 +9,7 @@
 // Handles I/O for the Jukebox
 // Manages Jukebox metadata files and recording status
 
-#include <SDL2/SDL_audio.h>
+#include <SDL_audio.h>
 #include "mmu.h"
 #include "common/util.h"
 

--- a/src/gba/lcd.h
+++ b/src/gba/lcd.h
@@ -9,8 +9,8 @@
 // Draws background, window, and sprites to screen
 // Responsible for blitting pixel data and limiting frame rate
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_opengl.h"
+#include "SDL.h"
+#include "SDL_opengl.h"
 #include "mmu.h"
 
 #ifndef GBA_LCD

--- a/src/gba/mmu.h
+++ b/src/gba/mmu.h
@@ -18,7 +18,7 @@
 #include <map>
 
 #ifdef GBE_NETPLAY
-#include <SDL2/SDL_net.h>
+#include <SDL_net.h>
 #endif
 
 #include "common.h"

--- a/src/gba/play_yan.cpp
+++ b/src/gba/play_yan.cpp
@@ -11,7 +11,7 @@
 // Nintendo MP3 Player handled separately (see nmp.cpp)
 
 #ifdef GBE_IMAGE_FORMATS
-#include <SDL2/SDL_image.h>
+#include <SDL_image.h>
 #endif
 
 #include <filesystem>

--- a/src/gba/sio.h
+++ b/src/gba/sio.h
@@ -13,7 +13,7 @@
 #define GBA_SIO
 
 #ifdef GBE_NETPLAY
-#include <SDL2/SDL_net.h>
+#include <SDL_net.h>
 #endif
 
 #include "mmu.h"

--- a/src/gba/tv_tuner.cpp
+++ b/src/gba/tv_tuner.cpp
@@ -9,7 +9,7 @@
 // Handles I/O for the Agatsuma TV Tuner (ATVT)
 
 #ifdef GBE_IMAGE_FORMATS
-#include <SDL2/SDL_image.h>
+#include <SDL_image.h>
 #endif
 
 #include <ctime>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 #include "min/core.h"
 #include "common/config.h"
 
-#include <SDL2/SDL_main.h>
+#include <SDL_main.h>
 
 int main(int argc, char* args[])
 {

--- a/src/min/apu.h
+++ b/src/min/apu.h
@@ -12,8 +12,8 @@
 #ifndef PM_APU
 #define PM_APU
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_audio.h>
+#include <SDL.h>
+#include <SDL_audio.h>
 #include "mmu.h"
 
 class MIN_APU

--- a/src/min/core.cpp
+++ b/src/min/core.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 
 #ifdef GBE_IMAGE_FORMATS
-#include <SDL2/SDL_image.h>
+#include <SDL_image.h>
 #endif
 
 #include "common/util.h"

--- a/src/min/gamepad.h
+++ b/src/min/gamepad.h
@@ -11,7 +11,7 @@
 #ifndef PM_GAMEPAD
 #define PM_GAMEPAD
 
-#include "SDL2/SDL.h"
+#include "SDL.h"
 #include <iostream>
 
 #include "common.h"

--- a/src/min/lcd.h
+++ b/src/min/lcd.h
@@ -9,8 +9,8 @@
 // Draws background and sprites to screen
 // Responsible for blitting pixel data and limiting frame rate
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_opengl.h"
+#include "SDL.h"
+#include "SDL_opengl.h"
 #include "mmu.h"
 
 #ifndef PM_LCD

--- a/src/min/mmu.h
+++ b/src/min/mmu.h
@@ -12,7 +12,7 @@
 #define PM_MMU
 
 #ifdef GBE_NETPLAY
-#include <SDL2/SDL_net.h>
+#include <SDL_net.h>
 #endif
 
 #include <fstream>

--- a/src/nds/apu.h
+++ b/src/nds/apu.h
@@ -12,8 +12,8 @@
 #ifndef NDS_APU
 #define NDS_APU
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_audio.h>
+#include <SDL.h>
+#include <SDL_audio.h>
 #include "mmu.h"
 
 class NTR_APU

--- a/src/nds/core.cpp
+++ b/src/nds/core.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 
 #ifdef GBE_IMAGE_FORMATS
-#include <SDL2/SDL_image.h>
+#include <SDL_image.h>
 #endif
 
 #include "common/util.h"

--- a/src/nds/gamepad.h
+++ b/src/nds/gamepad.h
@@ -12,7 +12,7 @@
 #ifndef NDS_GAMEPAD
 #define NDS_GAMEPAD
 
-#include "SDL2/SDL.h"
+#include "SDL.h"
 #include <string>
 #include <iostream>
 

--- a/src/nds/lcd.h
+++ b/src/nds/lcd.h
@@ -9,8 +9,8 @@
 // Draws background, window, and sprites to screen
 // Responsible for blitting pixel data and limiting frame rate
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_opengl.h"
+#include "SDL.h"
+#include "SDL_opengl.h"
 #include "mmu.h"
 #include "common/gx_util.h"
 

--- a/src/qt/general_settings.h
+++ b/src/qt/general_settings.h
@@ -12,7 +12,7 @@
 #ifndef SETTINGS_GBE_QT
 #define SETTINGS_GBE_QT
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <QtWidgets>
 

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -10,7 +10,7 @@
 
 #include "render.h"
  
-#include <SDL2/SDL_main.h>
+#include <SDL_main.h>
 
 int main(int argc, char* args[]) 
 {

--- a/src/qt/qt_common.cpp
+++ b/src/qt/qt_common.cpp
@@ -6,7 +6,7 @@
 // Date : July 15, 2015
 // Description : Common functions and definitions for Qt
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <QtWidgets>
 

--- a/src/sgb/core.cpp
+++ b/src/sgb/core.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 
 #ifdef GBE_IMAGE_FORMATS
-#include <SDL2/SDL_image.h>
+#include <SDL_image.h>
 #endif
 
 #include "common/util.h"

--- a/src/sgb/gamepad.h
+++ b/src/sgb/gamepad.h
@@ -13,7 +13,7 @@
 #ifndef SGB_GAMEPAD
 #define SGB_GAMEPAD
 
-#include "SDL2/SDL.h"
+#include "SDL.h"
 #include <string>
 #include <iostream>
 

--- a/src/sgb/lcd.h
+++ b/src/sgb/lcd.h
@@ -12,8 +12,8 @@
 #ifndef SGB_VID
 #define SGB_VID
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_opengl.h"
+#include "SDL.h"
+#include "SDL_opengl.h"
 #include "dmg/mmu.h"
 
 class SGB_LCD


### PR DESCRIPTION
The correct way to reference SDL headers is without the SDL2/ prefix. Take OpenBSD, for example. SDL2's SDL.h is located at /usr/local/include/SDL2/SDL.h. On OpenBSD, neither /usr/local/include nor /usr/local/include/SDL2 are in the compiler's default search path. CMake, like `sdl2-config` and `pkg-config`, does the right thing by adding /usr/local/include/SDL2 to the compiler search path. But GBE+ fails to build, because /usr/local/include/SDL2/SDL2/SDL.h does not exist.

There’s no risk of picking up headers from the wrong SDL version, because even on non‐OpenBSD platforms, nobody’s adding include/SDL/ or include/SDL2/ or include/SDL3/ to the compiler search path unless the build system requests it.