### PR TITLE
[Qt] Fix a couple of deprecation warnings

### DIFF
--- a/src/qt/debug_dmg.cpp
+++ b/src/qt/debug_dmg.cpp
@@ -905,7 +905,7 @@ dmg_debug::dmg_debug(QWidget *parent) : QDialog(parent)
 	mem_values->setReadOnly(true);
 	mem_values->setFixedWidth(500);
 	mem_values->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-	mem_values->setTabStopWidth(28);
+	mem_values->setTabStopDistance(28);
 	mem_values->setFont(mono_font);
 
 	mem_ascii = new QTextEdit(mem_set);

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -18,7 +18,6 @@ int main(int argc, char* args[])
 
 	config::use_external_interfaces = true;
 
-	QApplication::setAttribute(Qt::AA_X11InitThreads);
 	QApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton);
 	QApplication app(argc, args);
 


### PR DESCRIPTION
- The Qt::AA_X11InitThreads application attribute is obsolete and does nothing since [Qt 5.6](https://doc.qt.io/archives/qt-5.6/qt.html#ApplicationAttribute-enum) (released in [2016](https://web.archive.org/web/20191022235449/https://www.qt.io/blog/2016/03/16/qt-5-6-released))

- The QTextEdit::setTabWidth method has been deprecated and replaced by QTextEdit::setTabDistance since [Qt 5.10](https://doc.qt.io/archives/qt-5.10/qtextedit-obsolete.html) (released in [2017](https://web.archive.org/web/20171207120017/http://blog.qt.io/blog/2017/12/07/qt-5-10-released/))