### PR TITLE
[Qt] Port the OpenGL screen widget to base Qt QOpenGLWidget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,10 +55,9 @@ endif()
 option(QT_GUI "Enable the Qt GUI" ON)
 
 if(QT_GUI)
-	find_package(Qt5OpenGL REQUIRED)
 	find_package(Qt5Widgets REQUIRED)
 	find_package(Qt5Gui REQUIRED)
-	set(GBE_QT_LIBS Qt5::Gui Qt5::Widgets Qt5::OpenGL)
+	set(GBE_QT_LIBS Qt5::Gui Qt5::Widgets)
 endif()
 
 add_subdirectory(src)

--- a/src/qt/main_menu.cpp
+++ b/src/qt/main_menu.cpp
@@ -1492,7 +1492,7 @@ void main_menu::screenshot()
 		//Save OpenGL screen
 		if(config::use_opengl)
 		{
-			QImage img = hw_screen->grabFrameBuffer();
+			QImage img = hw_screen->grabFramebuffer();
 			QRect crop(0, 0, img.width(), img.height());
 
 			float original_ratio = float(config::sys_width) / config::sys_height;

--- a/src/qt/render.cpp
+++ b/src/qt/render.cpp
@@ -57,7 +57,7 @@ void render_screen_hw(SDL_Surface* image)
 
 	qt_gui::final_screen = image;
 
-	if(qt_gui::draw_surface != NULL) { qt_gui::draw_surface->hw_screen->updateGL(); }
+	if(qt_gui::draw_surface != NULL) { qt_gui::draw_surface->hw_screen->update(); }
 
 	QApplication::processEvents();
 }

--- a/src/qt/screens.cpp
+++ b/src/qt/screens.cpp
@@ -80,11 +80,11 @@ void soft_screen::resizeEvent(QResizeEvent* event)
 }
 
 /****** Hardware screen constructor ******/
-hard_screen::hard_screen(QWidget *parent) : QGLWidget(parent)
+hard_screen::hard_screen(QWidget *parent) : QOpenGLWidget(parent)
 {
 	//Set up Qt to use OpenGL 3.3
 	screen_format.setVersion(3, 3);
-	screen_format.setProfile(QGLFormat::CoreProfile);
+	screen_format.setProfile(QSurfaceFormat::CoreProfile);
 	screen_format.setSwapInterval(0);
 	setFormat(screen_format);
 
@@ -219,6 +219,8 @@ void hard_screen::resizeEvent(QResizeEvent* event)
 
 	gwin.resize(width(), height());
 	calculate_screen_size();
+
+	QOpenGLWidget::resizeEvent(event);
 }
 
 /****** Reloads fragment and vertex shaders ******/

--- a/src/qt/screens.h
+++ b/src/qt/screens.h
@@ -12,8 +12,6 @@
 #define SCREENS_GBE_QT
 
 #include <QtWidgets>
-#include <QGLWidget>
-#include <QGLFormat>
 
 #include "ogl_manager.h"
 
@@ -34,13 +32,13 @@ class soft_screen : public QWidget
 	void resizeEvent(QResizeEvent* event);
 };
 
-class hard_screen : public QGLWidget
+class hard_screen : public QOpenGLWidget
 {
 	Q_OBJECT
 	
 	public:
 	hard_screen(QWidget *parent = 0);
-	QGLFormat screen_format;
+	QSurfaceFormat screen_format;
 
 	ogl_manager gwin;
 


### PR DESCRIPTION
The Qt OpenGL module (classes prefixed by 'QGL') was deprecated with Qt 5.4. In replacement, the official documentation [recommends](https://doc.qt.io/archives/qt-5.15/qglwidget.html#details) to use the Qt GUI OpenGL classes. This port also facilitates migration to Qt 6, where the old Qt OpenGL module has been removed.