### PR TITLE
Simplify screen widgets implementation and clean up main_menu

### DIFF
--- a/src/qt/main_menu.cpp
+++ b/src/qt/main_menu.cpp
@@ -310,9 +310,6 @@ main_menu::main_menu(QWidget *parent) : QWidget(parent)
 	warning_box->setIcon(QMessageBox::Warning);
 	warning_box->hide();
 
-	display_width = QApplication::desktop()->screenGeometry().width();
-	display_height = QApplication::desktop()->screenGeometry().height();
-
 	fullscreen_mode = false;
 	is_sgb_core = false;
 }
@@ -943,7 +940,7 @@ void main_menu::boot_game()
 
 	findChild<QAction*>("pause_action")->setChecked(false);
 
-	menu_height = menu_bar->height();
+	int menu_height = menu_bar->height();
 
 	//Determine Gameboy type based on file name
 	//Note, DMG and GBC games are automatically detected in the Gameboy MMU, so only check for GBA and NDS types here
@@ -1126,6 +1123,7 @@ void main_menu::paintEvent(QPaintEvent* event)
 {
 	if(qt_gui::screen != NULL)
 	{
+		int menu_height = menu_bar->height();
 		//Check for resize
 		if(settings->resize_screen)
 		{

--- a/src/qt/main_menu.h
+++ b/src/qt/main_menu.h
@@ -40,12 +40,6 @@ class main_menu : public QWidget
 
 	soft_screen* sw_screen;
 	hard_screen* hw_screen;
-	
-	u32 screen_height;
-	u32 screen_width;
-	u32 display_height;
-	u32 display_width;
-	int menu_height;
 
 	bool fullscreen_mode;
 	bool is_sgb_core;

--- a/src/qt/screens.cpp
+++ b/src/qt/screens.cpp
@@ -63,22 +63,6 @@ void soft_screen::paintEvent(QPaintEvent* event)
 	}
 }
 
-/****** Software screen resize event ******/
-void soft_screen::resizeEvent(QResizeEvent* event)
-{
-	if(main_menu::gbe_plus == NULL) { return; }
-
-	//Grab test dimensions, look at max resolution for fullscreen dimensions
-	u32 test_width = qt_gui::draw_surface->fullscreen_mode ? qt_gui::draw_surface->display_width : qt_gui::draw_surface->width();
-	u32 test_height = qt_gui::draw_surface->fullscreen_mode ? qt_gui::draw_surface->display_height : (qt_gui::draw_surface->height() - qt_gui::draw_surface->menu_height);
-
-	//Adjust screen to fit expected dimensions no matter what
-	if((width() != test_width) || (height() != test_height))
-	{
-		resize(test_width, test_height);
-	}
-}
-
 /****** Hardware screen constructor ******/
 hard_screen::hard_screen(QWidget *parent) : QOpenGLWidget(parent)
 {
@@ -200,27 +184,15 @@ void hard_screen::paintGL()
 }
 
 /****** Hardware screen resize event ******/
-void hard_screen::resizeEvent(QResizeEvent* event)
+void hard_screen::resizeGL(int width, int height)
 {
 	if(main_menu::gbe_plus == NULL) { return; }
 
-	//Grab test dimensions, look at max resolution for fullscreen dimensions
-	u32 test_width = qt_gui::draw_surface->fullscreen_mode ? qt_gui::draw_surface->display_width : qt_gui::draw_surface->width();
-	u32 test_height = qt_gui::draw_surface->fullscreen_mode ? qt_gui::draw_surface->display_height : (qt_gui::draw_surface->height() - qt_gui::draw_surface->menu_height);
+	config::win_width = width;
+	config::win_height = height;
 
-	//Adjust screen to fit expected dimensions no matter what
-	if((width() != test_width) || (height() != test_height))
-	{
-		resize(test_width, test_height);
-	}
-
-	config::win_width = width();
-	config::win_height = height();
-
-	gwin.resize(width(), height());
+	gwin.resize(width, height);
 	calculate_screen_size();
-
-	QOpenGLWidget::resizeEvent(event);
 }
 
 /****** Reloads fragment and vertex shaders ******/

--- a/src/qt/screens.h
+++ b/src/qt/screens.h
@@ -29,7 +29,6 @@ class soft_screen : public QWidget
 
 	protected:
 	void paintEvent(QPaintEvent* event);
-	void resizeEvent(QResizeEvent* event);
 };
 
 class hard_screen : public QOpenGLWidget
@@ -53,7 +52,7 @@ class hard_screen : public QOpenGLWidget
 	protected:
 	void initializeGL();
 	void paintGL();
-	void resizeEvent(QResizeEvent* event);
+	void resizeGL(int width, int height);
 };
 
 #endif //SCREENS_GBE_QT 


### PR DESCRIPTION
Manually resizing the *_screen widgets is unnecessary and only makes the code more complex with no benefit. Removing that code also makes possible to remove a call to QApplication::desktop()->screenGeometry(), which is deprecated.

I suppose this used to be a workaround for Qt resizing or part of some functionality that was later removed, but I've tested it with the latest version of Qt 5 (5.15) and resizing behaves exactly the same with or without this code.